### PR TITLE
設定画面からUI言語を変更したらブラックアウトする

### DIFF
--- a/packages/frontend/src/pages/settings/general.vue
+++ b/packages/frontend/src/pages/settings/general.vue
@@ -260,6 +260,7 @@ const useGroupedNotifications = computed(defaultStore.makeGetterSetter('useGroup
 watch(lang, () => {
 	miLocalStorage.setItem('lang', lang.value as string);
 	miLocalStorage.removeItem('locale');
+  miLocalStorage.removeItem('localeVersion');
 });
 
 watch(fontSize, () => {


### PR DESCRIPTION
## 原因
1. 設定画面からUI言語を変更する
2. ローカルストレージからlocale（UIの文言が格納された値）が削除される
3. 強制リロード
4. 本来であればここで変更後のUI言語ファイルがDL→ローカルストレージのlocaleに再設定される…が、localeVersionは変わってないのでその処理が行われない
5. ただlocaleが消えただけになり、文言データが行方不明に
6. 描画失敗（ブラックアウト）

## 対策
2の段階でlocaleVersionも一緒に消すようにして4が狙い通りに動くようにした