### PR TITLE
fix tabler load

### DIFF
--- a/packages/frontend/src/_dev_boot_.ts
+++ b/packages/frontend/src/_dev_boot_.ts
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and other misskey contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+// devモードで起動される際（index.htmlを使うとき）はrouterが暴発してしまってうまく読み込めない。
+// よって、devモードとして起動されるときはビルド時に組み込む形としておく。
+// (pnpm start時はpugファイルの中で静的リソースとして読み込むようになっており、この問題は起こっていない)
+import '@tabler/icons-webfont/tabler-icons.scss';
+
+import('@/_boot_.js');

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -13,16 +13,12 @@
 		content="default-src 'self';
 		  script-src 'self';
 		  style-src 'self' 'unsafe-inline';
-		  img-src 'self' data: www.google.com xn--931a.moe  127.0.0.1:5173 127.0.0.1:3000"
+		  img-src 'self' data: www.google.com xn--931a.moe localhost:3000 localhost:5137 127.0.0.1:5173 127.0.0.1:3000"
 	/>
-
-	<link rel="stylesheet" href="@tabler/icons-webfont/tabler-icons.css">
-	<link rel="stylesheet" href="./style.scss" />
-
 </head>
 
 <body>
 <div id="app"></div>
-<script type="module" src="./_boot_.ts"></script>
+<script type="module" src="./_dev_boot_.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
`@tabler/icons-webfont/tabler-icons.scss` の読み込みがうまくいっていなかったのを修正。

原因としては、routerにつかまって意図せずルーティングされてしまったものと推測。
変更前は/assetsを読みに行っており、viteのプロキシ機能によりバックエンドへ転送されていたため発生していなかった。

静的ファイルとしての読み込みは行わず、tsファイルからimportする形で対応することにより回避した。

なお、以下の差分は今までの開発などでローカルにテストデータを蓄えている開発者各位に向けたものである。
（127.0.0.1のみだと画像などがブロックされて見えない）
```
localhost:3000 localhost:5137
```