### PR TITLE
favstar

### DIFF
--- a/favstar-highlight-investigation.md
+++ b/favstar-highlight-investigation.md
@@ -1,0 +1,125 @@
+# ハイライト集計ロジック / 集計タイミング 調査メモ
+
+「リアクションベースでキュレーションしたつもりだが不完全」とのことなので、現状の実装を集計タイミング / 集計値 / 表示判定の3軸でほどいてみました。結論として、**バックエンド側のキュレーションとフロントエンドの色付け判定が完全に独立しており、リアクション除外設定や採用確率がフロントの色付けに反映されない** という構造的なズレがあります。
+
+---
+
+## 1. 集計タイミング
+
+| トリガ | コード | スコア | rateFactor | excludeEmojis | 備考 |
+|---|---|---|---|---|---|
+| **リアクション付与** | `ReactionService.createReaction` `packages/backend/src/core/ReactionService.ts:212-231` | `+1` | 適用 | 適用 | セルフリアクション除外、3日以内のノートのみ |
+| **リノート作成** | `NoteCreateService.incRenoteCount` `packages/backend/src/core/NoteCreateService.ts:902-914` | `+5` | 適用 | **未適用** | リノートも Featured ランキングに乗る |
+
+つまり「ハイライトの集計」は厳密にはリアクションだけではなく、**リアクション + リノート** の合算スコアで Redis sorted set (`featuredGlobalNotesRanking` 等) を更新しています。リアクション以外も寄与している時点で「リアクションベース」とは言い切れません。
+
+## 2. 集計値と表示判定の不整合（本丸）
+
+### バックエンドが管理しているもの
+`FeaturedService.updateGlobalNotesRanking` ほかが Redis sorted set にスコア累積。これは **「みつける / フィーチャー」タイムラインに何を出すか** を決めるためのもの。
+
+- `highlightRateFactor` … スコア加算の発生確率（既定 30%）
+- `highlightExcludeEmojis` … リアクションのみ、特定絵文字をスコア加算から除外
+- 3日以内のノートのみ集計対象
+- セルフリアクション・チャンネル外の `replyId != null` 等を除外
+
+### フロントエンドが色付けに使っているもの
+`MkNote.vue:67`
+
+```vue
+<div :class="[$style.text, {
+  [$style.akafav]: featured && note.reactionCount >= highlightPopularityThreshold.highPopularity,
+  [$style.aofav]: featured && note.reactionCount >= highlightPopularityThreshold.midPopularity
+                  && note.reactionCount < highlightPopularityThreshold.highPopularity
+}]">
+```
+
+ここで使っている `note.reactionCount` は `NoteEntityService.ts:414` で次のように計算されているもの。
+
+```ts
+reactionCount: Object.values(reactions).reduce((a, b) => a + b, 0),
+```
+
+つまり **そのノートに付いた全リアクション数の単純合計**。`highlightExcludeEmojis` のフィルタも採用確率もここには一切効きません。
+
+### 帰結する問題
+
+1. **`highlightExcludeEmojis` がフロント色付けに無効**
+   除外指定した絵文字でリアクションされても `reactionCount` には含まれるため、それだけで赤ふぁぼ/青ふぁぼに到達してしまう。ユーザの「キュレーションしたつもり」は Featured タイムラインに乗るか乗らないかの選別にしか効いていない。
+
+2. **`featured` プロップが `explore.featured.vue` でしか `true` にならない**
+   `MkNotesTimeline.vue` の他の経由（ホーム TL 等）は `featured=false` のままなので、Featured タイムライン以外では絶対に色が付かない。「リアクションたくさんついたノートは青ふぁぼ／赤ふぁぼ」という README の説明（スコープ言及なし）と実装の挙動が食い違っている。
+
+3. **赤ふぁぼ閾値の境界条件**
+   `note.reactionCount >= midPopularity && < highPopularity` で青、`>= highPopularity` で赤。`mid` を `high` 以上に設定すると青のレンジがゼロになる。バリデーション無し。
+
+4. **Featured ランキングのスコアと表示色が乖離**
+   - リノートはランキングに +5 寄与するが `reactionCount` には影響しない → 「Featured 上位なのに色が付かないノート」が出る。
+   - 逆に Featured に乗らない（rateFactor で間引かれた）ノートでも、`featured=true` の文脈で表示されればリアクションが多ければ色が付く。Featured 上の他人のリアクションでもカウントされるので、自然な体験ではあるが「ランキング = 色付け」ではない。
+
+## 3. `highlightExcludeEmojis` 自体のパース問題
+
+`ReactionService.ts:212`
+
+```ts
+const excludeEmojis = this.meta.highlightExcludeEmojis.split(/:\n/).filter(v => v);
+```
+
+- 区切り文字が **`:\n` というシーケンス**。つまり「`:` の直後に LF」がある時のみ分割される。
+- 管理画面の入力 (`MkTextarea`) には `:emoji_name:` を改行区切りで並べる想定だが、
+  - 末尾要素には改行が無く `split` 対象外 → 最後の `:emoji_name:` がそのまま残る
+  - 先頭の `:` は最初の要素にだけ残り、その後の要素は `emoji_name:` で始まる文字列になる
+  - 結果、要素の文字列フォーマットがバラバラに
+- 比較対象の `reaction` は内部表現上 `:name@.:` / `:name@host:` 形式なので、`includes(reaction)` がそもそもまずマッチしない可能性が高い。
+- Unicode 絵文字の場合は `reaction` が生の絵文字文字列（`👍` 等）だが、入力テキストは `:thumbsup:` 系の MFM 表記であり、これも一致しない。
+
+→ **実質的に「除外絵文字」設定はほぼ常に効いていない可能性が大**。
+
+## 4. `update-meta.ts` の保存ロジック
+
+`packages/backend/src/server/api/endpoints/admin/update-meta.ts:778`
+
+```ts
+if (ps.highlightRateFactor) {
+    set.highlightRateFactor = ps.highlightRateFactor;
+    set.highlightMidPopularityThreshold = ps.highlightMidPopularityThreshold;
+    set.highlightHighPopularityThreashold = ps.highlightHighPopularityThreashold;
+    set.highlightExcludeEmojis = ps.highlightExcludeEmojis;
+}
+```
+
+- 4つを **`highlightRateFactor` の truthy 判定一発でまとめてセット**している。
+- `highlightRateFactor` を 0 にした（＝ハイライト機能を停止したい）ケースで、他3項目の更新も無視される。
+- 個別に `!== undefined` 判定で `set.x = ps.x` するのが正しい形。
+
+## 5. その他細かい点
+
+- `paramDef` 側で `optinal: false` (タイポ。`optional` ではない) になっており、`type-narrowing` 上は最適化されない。
+- フィールド名 `highlightHighPopularityThreashold` も `Threashold` → `Threshold` のタイポが各所に伝播している（DB カラム名含むので修正には migration 必要）。
+- リノート側 `incRenoteCount` には `excludeEmojis` フィルタ無し（そもそも絵文字無関係なので問題ではないが、`highlightRateFactor` を「リアクション採用確率」と説明している admin 画面と齟齬）。
+
+---
+
+## 修正方針の提案
+
+「リアクションベースでキュレーション」を素直に実現するなら、選択肢は2つ。
+
+### A. フロント側で `note.reactions` を再集計する（小手先・既存DB変更なし）
+`MkNote.vue` の色付け判定で `note.reactionCount` ではなく、`instance.highlightExcludeEmojis` を反映した「除外後リアクション数」を `computed` で算出する。
+
+メリット: マイグレーション不要、最小差分。
+デメリット: 除外絵文字のパース仕様をフロントで正規化する必要がある（前述 3 の問題を片付ける）。`featured` プロップに依存している現状の表示スコープ制限はそのまま。
+
+### B. キュレーション結果をノートに乗せる（本筋）
+`NoteEntityService.pack` 内で `featuredService.isHighlighted(noteId)` 的に判定して、サーバ側で `highlightTier: 'mid' | 'high' | null` を返す。フロントは `featured` プロップではなくこの値を見て色付け。
+
+メリット: ロジックがサーバ集約、リノート寄与も含めた本来の「ハイライト」体験が全画面で一貫。
+デメリット: pack 毎の Redis 参照コスト、または事前に Note カラムへ反映するマイグレーション。
+
+### 直すべき最低限のバグ修正（A/B どちらでも）
+
+- [ ] `highlightExcludeEmojis.split(/:\n/)` の区切り仕様見直し（改行区切り＋トリム＋カスタム絵文字フォーマット正規化）
+- [ ] `update-meta.ts:778` の `if (ps.highlightRateFactor)` ガードを項目別 `!== undefined` に分解
+- [ ] `paramDef` 内の `optinal` タイポ修正
+- [ ] (低優先) `Threashold` カラム名のリネーム（migration 込み）
+- [ ] `MkNote` の `featured` フラグでの表示スコープ制限を意図通りか確認（ホーム TL でも色を出すなら撤廃）

--- a/packages/backend/migration/1780358400000-highlightMetaColumns.js
+++ b/packages/backend/migration/1780358400000-highlightMetaColumns.js
@@ -9,13 +9,13 @@ export class HighlightMetaColumns1780358400000 {
     async up(queryRunner) {
         await queryRunner.query(`ALTER TABLE "meta" ADD "highlightRateFactor" integer NOT NULL DEFAULT 30`);
         await queryRunner.query(`ALTER TABLE "meta" ADD "highlightMidPopularityThreshold" integer NOT NULL DEFAULT 3`);
-        await queryRunner.query(`ALTER TABLE "meta" ADD "highlightHighPopularityThreashold" integer NOT NULL DEFAULT 5`);
+        await queryRunner.query(`ALTER TABLE "meta" ADD "highlightHighPopularityThreshold" integer NOT NULL DEFAULT 5`);
         await queryRunner.query(`ALTER TABLE "meta" ADD "highlightExcludeEmojis" text NOT NULL DEFAULT ''`);
     }
 
     async down(queryRunner) {
         await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightExcludeEmojis"`);
-        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightHighPopularityThreashold"`);
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightHighPopularityThreshold"`);
         await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightMidPopularityThreshold"`);
         await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightRateFactor"`);
     }

--- a/packages/backend/migration/1780358400000-highlightMetaColumns.js
+++ b/packages/backend/migration/1780358400000-highlightMetaColumns.js
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class HighlightMetaColumns1780358400000 {
+    name = 'HighlightMetaColumns1780358400000'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" ADD "highlightRateFactor" integer NOT NULL DEFAULT 30`);
+        await queryRunner.query(`ALTER TABLE "meta" ADD "highlightMidPopularityThreshold" integer NOT NULL DEFAULT 3`);
+        await queryRunner.query(`ALTER TABLE "meta" ADD "highlightHighPopularityThreashold" integer NOT NULL DEFAULT 5`);
+        await queryRunner.query(`ALTER TABLE "meta" ADD "highlightExcludeEmojis" text NOT NULL DEFAULT ''`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightExcludeEmojis"`);
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightHighPopularityThreashold"`);
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightMidPopularityThreshold"`);
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "highlightRateFactor"`);
+    }
+}

--- a/packages/backend/scripts/fake-highlights.mjs
+++ b/packages/backend/scripts/fake-highlights.mjs
@@ -1,0 +1,313 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ *
+ * ハイライト用のテストデータを捏造するスクリプト。
+ *
+ * 実行方法:
+ *   cd packages/backend
+ *   node scripts/fake-highlights.mjs
+ *
+ * - ローカルユーザーが足りなければダミーを追加生成
+ * - 直近のローカル/public/ルートノート 13件を対象に
+ *   赤3件(>=highlightHighPopularityThreshold)
+ *   青5件(highlightMidPopularityThreshold <= n < high)
+ *   通常5件 (low)
+ *   になるよう note_reaction を補充
+ * - Redis の featuredGlobalNotesRanking に登録
+ */
+
+import Redis from 'ioredis';
+import { generateKeyPair, randomBytes } from 'node:crypto';
+import { promisify } from 'node:util';
+import { loadConfig } from '../src-js/config.js';
+import { createPostgresDataSource } from '../src-js/postgres.js';
+import { genAidx } from '../src-js/misc/id/aidx.js';
+
+const generateKeyPairAsync = promisify(generateKeyPair);
+
+const RED_COUNT = 3;
+const BLUE_COUNT = 5;
+const NORMAL_COUNT = 5;
+const TOTAL_NOTES = RED_COUNT + BLUE_COUNT + NORMAL_COUNT;
+
+const EMOJIS = ['❤', '👍', '🍣', '🎉', '😆', '🥳', '✨', '🚀', '🌸', '🍰'];
+
+const FAVSTAR_USER_PREFIX = 'fav_test_';
+
+const featuredEpoc = new Date('2023-01-01T00:00:00Z').getTime();
+const GLOBAL_NOTES_RANKING_WINDOW = 1000 * 60 * 60 * 24 * 3;
+
+function pickEmoji(i) {
+	return EMOJIS[i % EMOJIS.length];
+}
+
+function shuffle(arr) {
+	const a = [...arr];
+	for (let i = a.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[a[i], a[j]] = [a[j], a[i]];
+	}
+	return a;
+}
+
+async function createDummyUser(ds, idx) {
+	const id = genAidx(Date.now());
+	const username = `${FAVSTAR_USER_PREFIX}${id}`;
+	const usernameLower = username.toLowerCase();
+	const token = randomBytes(8).toString('hex');
+
+	const { publicKey, privateKey } = await generateKeyPairAsync('rsa', {
+		modulusLength: 2048,
+		publicKeyEncoding: { type: 'spki', format: 'pem' },
+		privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+	});
+
+	await ds.transaction(async (manager) => {
+		await manager.query(
+			`INSERT INTO "user" (
+				"id","username","usernameLower","host","token","name"
+			) VALUES ($1,$2,$3,NULL,$4,$5)`,
+			[id, username, usernameLower, token, `Favstar Test ${idx}`],
+		);
+		await manager.query(
+			`INSERT INTO "user_profile" ("userId") VALUES ($1)`,
+			[id],
+		);
+		await manager.query(
+			`INSERT INTO "user_keypair" ("userId","publicKey","privateKey") VALUES ($1,$2,$3)`,
+			[id, publicKey, privateKey],
+		);
+	});
+
+	return id;
+}
+
+async function ensureLocalUsers(ds, needed) {
+	const existing = await ds.query(
+		`SELECT "id" FROM "user" WHERE "host" IS NULL AND "isSuspended" = false AND "isDeleted" = false ORDER BY "id" DESC LIMIT $1`,
+		[Math.max(needed * 2, 20)],
+	);
+	let userIds = existing.map((r) => r.id);
+
+	const deficit = needed - userIds.length;
+	if (deficit > 0) {
+		console.log(`既存ローカルユーザーが ${userIds.length} 人。あと ${deficit} 人ダミー作成します...`);
+		for (let i = 0; i < deficit; i++) {
+			const id = await createDummyUser(ds, userIds.length + 1);
+			userIds.push(id);
+			console.log(`  → 作成: ${id}`);
+		}
+	} else {
+		console.log(`既存ローカルユーザー ${userIds.length} 人を再利用します`);
+	}
+
+	return userIds;
+}
+
+const SAMPLE_NOTE_TEXTS = [
+	'今日はいい天気だね',
+	'ラーメン食べたい🍜',
+	'眠い…',
+	'コードレビューしてる',
+	'おはよう☀️',
+	'おやすみ🌙',
+	'お腹すいた',
+	'コーヒーうまい☕',
+	'仕事終わった〜',
+	'映画観たい',
+	'桜が綺麗',
+	'もうこんな時間',
+	'今日もお疲れ様',
+	'ねむい',
+	'お風呂入る',
+	'ご飯炊けた',
+	'散歩日和',
+	'ニャーン🐱',
+	'本読んでる📚',
+	'バグった',
+];
+
+async function createSampleNotes(ds, userIds, count) {
+	const created = [];
+	for (let i = 0; i < count; i++) {
+		const id = genAidx(Date.now() - i * 1000);
+		const userId = userIds[i % userIds.length];
+		const text = `${SAMPLE_NOTE_TEXTS[i % SAMPLE_NOTE_TEXTS.length]} (#${i + 1})`;
+		await ds.query(
+			`INSERT INTO "note" ("id","userId","visibility","text") VALUES ($1,$2,'public',$3)`,
+			[id, userId, text],
+		);
+		created.push({ id, userId, reactions: {} });
+		console.log(`  → note作成: ${id} (${text})`);
+	}
+	return created;
+}
+
+async function fetchCandidateNotes(ds) {
+	const sinceAidx = genAidx(Date.now() - 1000 * 60 * 60 * 24 * 2);
+
+	let notes = await ds.query(
+		`SELECT "id","userId","reactions"
+		 FROM "note"
+		 WHERE "visibility" = 'public'
+			AND "userHost" IS NULL
+			AND "replyId" IS NULL
+			AND "id" > $1
+		 ORDER BY "id" DESC
+		 LIMIT $2`,
+		[sinceAidx, TOTAL_NOTES * 2],
+	);
+
+	if (notes.length < TOTAL_NOTES) {
+		console.log(`2日以内のノートが ${notes.length} 件しかないので、3日以内に拡張します`);
+		const sinceAidx3d = genAidx(Date.now() - 1000 * 60 * 60 * 24 * 3);
+		notes = await ds.query(
+			`SELECT "id","userId","reactions"
+			 FROM "note"
+			 WHERE "visibility" = 'public'
+				AND "userHost" IS NULL
+				AND "replyId" IS NULL
+				AND "id" > $1
+			 ORDER BY "id" DESC
+			 LIMIT $2`,
+			[sinceAidx3d, TOTAL_NOTES * 2],
+		);
+	}
+
+	if (notes.length < TOTAL_NOTES) {
+		console.warn(`⚠️  対象ノートが ${notes.length} 件しかありません。先にローカル公開ノートを ${TOTAL_NOTES} 件以上投稿してください。`);
+	}
+
+	return notes.slice(0, TOTAL_NOTES);
+}
+
+async function getMetaThresholds(ds) {
+	const rows = await ds.query(
+		`SELECT "highlightMidPopularityThreshold","highlightHighPopularityThreshold" FROM "meta" LIMIT 1`,
+	);
+	if (rows.length === 0) {
+		return { mid: 3, high: 5 };
+	}
+	return {
+		mid: rows[0].highlightMidPopularityThreshold ?? 3,
+		high: rows[0].highlightHighPopularityThreshold ?? 5,
+	};
+}
+
+async function addReactions(ds, note, userIds, targetCount, emojiBase) {
+	const reactions = note.reactions ?? {};
+	const currentTotal = Object.values(reactions).reduce((a, b) => a + Number(b), 0);
+	const need = Math.max(0, targetCount - currentTotal);
+	if (need === 0) return 0;
+
+	const eligible = userIds.filter((uid) => uid !== note.userId);
+	if (eligible.length < need) {
+		console.warn(`  ノート ${note.id}: ユーザーが足りません (${eligible.length} < ${need})`);
+	}
+	const picks = shuffle(eligible).slice(0, need);
+
+	let added = 0;
+	for (let i = 0; i < picks.length; i++) {
+		const userId = picks[i];
+		const reaction = pickEmoji(emojiBase + i);
+		const rid = genAidx(Date.now());
+		try {
+			await ds.transaction(async (manager) => {
+				await manager.query(
+					`INSERT INTO "note_reaction" ("id","userId","noteId","reaction") VALUES ($1,$2,$3,$4)`,
+					[rid, userId, note.id, reaction],
+				);
+				await manager.query(
+					`UPDATE "note"
+					 SET "reactions" = jsonb_set("reactions", ARRAY[$1::text], (COALESCE("reactions"->>$1, '0')::int + 1)::text::jsonb)
+					 WHERE "id" = $2`,
+					[reaction, note.id],
+				);
+			});
+			added++;
+		} catch (e) {
+			// note_reactionの(userId,noteId) unique衝突は無視（同ユーザーが既にリアクション済み）
+			if (!String(e.message).includes('duplicate key')) {
+				console.warn(`  reaction insert失敗: ${e.message}`);
+			}
+		}
+	}
+	return added;
+}
+
+async function main() {
+	const config = loadConfig();
+	console.log(`DB: ${config.db.host}:${config.db.port}/${config.db.db}`);
+	console.log(`Redis: ${config.redis.host}:${config.redis.port} (prefix=${config.redis.keyPrefix})`);
+
+	const ds = createPostgresDataSource(config);
+	await ds.initialize();
+
+	const redis = new Redis({
+		host: config.redis.host,
+		port: config.redis.port,
+		family: config.redis.family,
+		password: config.redis.pass,
+		db: config.redis.db,
+		keyPrefix: config.redis.keyPrefix,
+	});
+
+	try {
+		const thresholds = await getMetaThresholds(ds);
+		console.log(`閾値: mid=${thresholds.mid}, high=${thresholds.high}`);
+
+		const userIds = await ensureLocalUsers(ds, Math.max(thresholds.high + 2, 8));
+
+		let notes = await fetchCandidateNotes(ds);
+		const noteDeficit = TOTAL_NOTES - notes.length;
+		if (noteDeficit > 0) {
+			console.log(`対象ノートが ${notes.length} 件しかないので、サンプルノートを ${noteDeficit} 件作成します`);
+			const created = await createSampleNotes(ds, userIds, noteDeficit);
+			notes = [...created, ...notes];
+		}
+		console.log(`対象ノート ${notes.length} 件`);
+
+		// 配列の前から赤→青→通常の順に当てる
+		const plan = [];
+		for (let i = 0; i < RED_COUNT; i++) plan.push({ kind: 'red', target: thresholds.high + 1 + (i % 3) });
+		for (let i = 0; i < BLUE_COUNT; i++) plan.push({ kind: 'blue', target: thresholds.mid + (i % Math.max(1, thresholds.high - thresholds.mid)) });
+		for (let i = 0; i < NORMAL_COUNT; i++) plan.push({ kind: 'normal', target: Math.max(0, thresholds.mid - 1 - (i % 2)) });
+
+		let emojiBase = 0;
+		const featuredItems = [];
+		for (let i = 0; i < notes.length && i < plan.length; i++) {
+			const { kind, target } = plan[i];
+			const added = await addReactions(ds, notes[i], userIds, target, emojiBase);
+			emojiBase += added;
+			featuredItems.push({ noteId: notes[i].id, kind, target });
+			console.log(`  [${kind}] note=${notes[i].id} target=${target} added=${added}`);
+		}
+
+		// Redis ランキング登録
+		const currentWindow = Math.floor((Date.now() - featuredEpoc) / GLOBAL_NOTES_RANKING_WINDOW);
+		const key = `featuredGlobalNotesRanking:${currentWindow}`;
+		console.log(`Redis ZADD → ${config.redis.keyPrefix}${key}`);
+		const tx = redis.multi();
+		for (let i = 0; i < featuredItems.length; i++) {
+			const item = featuredItems[i];
+			const score = (item.kind === 'red' ? 30 : item.kind === 'blue' ? 15 : 5) + (featuredItems.length - i);
+			tx.zadd(key, score, item.noteId);
+		}
+		tx.expire(key, Math.floor((GLOBAL_NOTES_RANKING_WINDOW * 3) / 1000), 'NX');
+		await tx.exec();
+
+		console.log('✅ ハイライト捏造完了');
+		console.log(`  赤: ${featuredItems.filter((x) => x.kind === 'red').length} 件`);
+		console.log(`  青: ${featuredItems.filter((x) => x.kind === 'blue').length} 件`);
+		console.log(`  通常: ${featuredItems.filter((x) => x.kind === 'normal').length} 件`);
+	} finally {
+		await ds.destroy();
+		redis.disconnect();
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -952,7 +952,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 			.execute();
 
 		// 30%の確率、3日以内に投稿されたノートの場合ハイライト用ランキング更新
-		if (Math.random() < 0.3 && (Date.now() - this.idService.parse(renote.id).date.getTime()) < 1000 * 60 * 60 * 24 * 3) {
+		if (Math.random() <= (this.meta.highlightRateFactor / 100) && (Date.now() - this.idService.parse(renote.id).date.getTime()) < 1000 * 60 * 60 * 24 * 3) {
 			if (renote.channelId != null) {
 				if (renote.replyId == null) {
 					this.featuredService.updateInChannelNotesRanking(renote.channelId, renote.id, 5);

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -123,7 +123,7 @@ export class ReactionService {
 		}
 
 		let reaction = _reaction ?? FALLBACK;
-
+		
 		if (note.reactionAcceptance === 'likeOnly' || ((note.reactionAcceptance === 'likeOnlyForRemote' || note.reactionAcceptance === 'nonSensitiveOnlyForLocalLikeOnlyForRemote') && (user.host != null))) {
 			reaction = '\u2764';
 		} else if (_reaction != null) {
@@ -209,9 +209,12 @@ export class ReactionService {
 				.execute();
 		}
 
+		const excludeEmojis = this.meta.highlightExcludeEmojis.split(/:\n/).filter(v => v);
+
 		// 30%の確率、セルフではない、3日以内に投稿されたノートの場合ハイライト用ランキング更新
 		if (
-			Math.random() < 0.3 &&
+			!excludeEmojis.includes(reaction) &&
+			Math.random() <= (this.meta.highlightRateFactor / 100) &&
 			note.userId !== user.id &&
 			(Date.now() - this.idService.parse(note.id).date.getTime()) < 1000 * 60 * 60 * 24 * 3
 		) {

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -209,7 +209,10 @@ export class ReactionService {
 				.execute();
 		}
 
-		const excludeEmojis = this.meta.highlightExcludeEmojis.split(/:\n/).filter(v => v);
+		const excludeEmojis = this.meta.highlightExcludeEmojis
+			.split('\n')
+			.map(v => v.trim())
+			.filter(v => v);
 
 		// 30%の確率、セルフではない、3日以内に投稿されたノートの場合ハイライト用ランキング更新
 		if (

--- a/packages/backend/src/core/entities/MetaEntityService.ts
+++ b/packages/backend/src/core/entities/MetaEntityService.ts
@@ -16,6 +16,13 @@ import type { Config } from '@/config.js';
 import { DI } from '@/di-symbols.js';
 import { DEFAULT_POLICIES } from '@/core/RoleService.js';
 
+type HighlightExtention = {
+	highlightRateFactor: number,
+	highlightMidPopularityThreshold: number,
+	highlightHighPopularityThreashold: number,
+	highlightExcludeEmojis: string
+}
+
 @Injectable()
 export class MetaEntityService {
 	constructor(
@@ -32,7 +39,7 @@ export class MetaEntityService {
 	) { }
 
 	@bindThis
-	public async pack(meta?: MiMeta): Promise<Packed<'MetaLite'>> {
+	public async pack(meta?: MiMeta): Promise<Packed<'MetaLite'> & HighlightExtention> {
 		let instance = meta;
 
 		if (!instance) {
@@ -65,7 +72,7 @@ export class MetaEntityService {
 			}
 		}
 
-		const packed: Packed<'MetaLite'> = {
+		const packed: Packed<'MetaLite'> & HighlightExtention = {
 			maintainerName: instance.maintainerName,
 			maintainerEmail: instance.maintainerEmail,
 
@@ -135,6 +142,11 @@ export class MetaEntityService {
 			noteSearchableScope: (this.config.fulltextSearch?.provider === 'meilisearch' && this.config.meilisearch?.scope === 'local') ? 'local' : 'global',
 			maxFileSize: this.config.maxFileSize,
 			federation: this.meta.federation,
+
+			highlightRateFactor: instance.highlightRateFactor,
+			highlightMidPopularityThreshold: instance.highlightMidPopularityThreshold,
+			highlightHighPopularityThreashold: instance.highlightHighPopularityThreashold,
+			highlightExcludeEmojis: instance.highlightExcludeEmojis,
 		};
 
 		return packed;

--- a/packages/backend/src/core/entities/MetaEntityService.ts
+++ b/packages/backend/src/core/entities/MetaEntityService.ts
@@ -17,11 +17,11 @@ import { DI } from '@/di-symbols.js';
 import { DEFAULT_POLICIES } from '@/core/RoleService.js';
 
 type HighlightExtention = {
-	highlightRateFactor: number,
-	highlightMidPopularityThreshold: number,
-	highlightHighPopularityThreashold: number,
-	highlightExcludeEmojis: string
-}
+	highlightRateFactor: number;
+	highlightMidPopularityThreshold: number;
+	highlightHighPopularityThreshold: number;
+	highlightExcludeEmojis: string;
+};
 
 @Injectable()
 export class MetaEntityService {
@@ -145,7 +145,7 @@ export class MetaEntityService {
 
 			highlightRateFactor: instance.highlightRateFactor,
 			highlightMidPopularityThreshold: instance.highlightMidPopularityThreshold,
-			highlightHighPopularityThreashold: instance.highlightHighPopularityThreashold,
+			highlightHighPopularityThreshold: instance.highlightHighPopularityThreshold,
 			highlightExcludeEmojis: instance.highlightExcludeEmojis,
 		};
 

--- a/packages/backend/src/models/Meta.ts
+++ b/packages/backend/src/models/Meta.ts
@@ -736,7 +736,7 @@ export class MiMeta {
 	@Column('integer', { default: 3 })
 	public highlightMidPopularityThreshold: number;
 	@Column('integer', { default: 5 })
-	public highlightHighPopularityThreashold: number;
+	public highlightHighPopularityThreshold: number;
 	@Column('text', { default: '' })
 	public highlightExcludeEmojis: string;
 }

--- a/packages/backend/src/models/Meta.ts
+++ b/packages/backend/src/models/Meta.ts
@@ -730,6 +730,15 @@ export class MiMeta {
 		showTimelineForVisitor: boolean;
 		showActivitiesForVisitor: boolean;
 	};
+
+	@Column('integer', { default: 30 })
+	public highlightRateFactor: number;
+	@Column('integer', { default: 3 })
+	public highlightMidPopularityThreshold: number;
+	@Column('integer', { default: 5 })
+	public highlightHighPopularityThreashold: number;
+	@Column('text', { default: '' })
+	public highlightExcludeEmojis: string;
 }
 
 export type SoftwareSuspension = {

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -596,6 +596,24 @@ export const meta = {
 				type: 'boolean',
 				optional: false, nullable: false,
 			},
+
+			highlightRateFactor: {
+				type: 'number',
+				optinal: false, nullable: false,
+			},
+
+			highlightMidPopularityThreshold: {
+				type: 'number',
+				optinal: false, nullable: false,
+			},
+			highlightHighPopularityThreashold: {
+				type: 'number',
+				optinal: false, nullable: false,
+			},
+			highlightExcludeEmojis: {
+				type: 'string',
+				optinal: false, nullable: false,
+			},
 		},
 	},
 } as const;
@@ -752,6 +770,10 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				remoteNotesCleaningExpiryDaysForEachNotes: instance.remoteNotesCleaningExpiryDaysForEachNotes,
 				remoteNotesCleaningMaxProcessingDurationInMinutes: instance.remoteNotesCleaningMaxProcessingDurationInMinutes,
 				showRoleBadgesOfRemoteUsers: instance.showRoleBadgesOfRemoteUsers,
+				highlightRateFactor: instance.highlightRateFactor,
+				highlightMidPopularityThreshold: instance.highlightMidPopularityThreshold,
+				highlightHighPopularityThreashold: instance.highlightHighPopularityThreashold,
+				highlightExcludeEmojis: instance.highlightExcludeEmojis,
 			};
 		});
 	}

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -606,7 +606,7 @@ export const meta = {
 				type: 'number',
 				optinal: false, nullable: false,
 			},
-			highlightHighPopularityThreashold: {
+			highlightHighPopularityThreshold: {
 				type: 'number',
 				optinal: false, nullable: false,
 			},
@@ -772,7 +772,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				showRoleBadgesOfRemoteUsers: instance.showRoleBadgesOfRemoteUsers,
 				highlightRateFactor: instance.highlightRateFactor,
 				highlightMidPopularityThreshold: instance.highlightMidPopularityThreshold,
-				highlightHighPopularityThreashold: instance.highlightHighPopularityThreashold,
+				highlightHighPopularityThreshold: instance.highlightHighPopularityThreshold,
 				highlightExcludeEmojis: instance.highlightExcludeEmojis,
 			};
 		});

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -225,7 +225,7 @@ export const paramDef = {
 		highlightMidPopularityThreshold: {
 			type: 'number',
 		},
-		highlightHighPopularityThreashold: {
+		highlightHighPopularityThreshold: {
 			type: 'number',
 		},
 		highlightExcludeEmojis: {
@@ -783,8 +783,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				set.highlightMidPopularityThreshold = ps.highlightMidPopularityThreshold;
 			}
 
-			if (ps.highlightHighPopularityThreashold !== undefined) {
-				set.highlightHighPopularityThreashold = ps.highlightHighPopularityThreashold;
+			if (ps.highlightHighPopularityThreshold !== undefined) {
+				set.highlightHighPopularityThreshold = ps.highlightHighPopularityThreshold;
 			}
 
 			if (ps.highlightExcludeEmojis !== undefined) {

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -218,6 +218,19 @@ export const paramDef = {
 		remoteNotesCleaningExpiryDaysForEachNotes: { type: 'number' },
 		remoteNotesCleaningMaxProcessingDurationInMinutes: { type: 'number' },
 		showRoleBadgesOfRemoteUsers: { type: 'boolean' },
+		highlightRateFactor: {
+			type: 'number',
+		},
+
+		highlightMidPopularityThreshold: {
+			type: 'number',
+		},
+		highlightHighPopularityThreashold: {
+			type: 'number',
+		},
+		highlightExcludeEmojis: {
+			type: 'string',
+		},
 	},
 	required: [],
 } as const;
@@ -760,6 +773,13 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			if (ps.showRoleBadgesOfRemoteUsers !== undefined) {
 				set.showRoleBadgesOfRemoteUsers = ps.showRoleBadgesOfRemoteUsers;
+			}
+
+			if (ps.highlightRateFactor) {
+				set.highlightRateFactor = ps.highlightRateFactor;
+				set.highlightMidPopularityThreshold = ps.highlightMidPopularityThreshold;
+				set.highlightHighPopularityThreashold = ps.highlightHighPopularityThreashold;
+				set.highlightExcludeEmojis = ps.highlightExcludeEmojis;
 			}
 
 			const before = await this.metaService.fetch(true);

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -775,10 +775,19 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				set.showRoleBadgesOfRemoteUsers = ps.showRoleBadgesOfRemoteUsers;
 			}
 
-			if (ps.highlightRateFactor) {
+			if (ps.highlightRateFactor !== undefined) {
 				set.highlightRateFactor = ps.highlightRateFactor;
+			}
+
+			if (ps.highlightMidPopularityThreshold !== undefined) {
 				set.highlightMidPopularityThreshold = ps.highlightMidPopularityThreshold;
+			}
+
+			if (ps.highlightHighPopularityThreashold !== undefined) {
 				set.highlightHighPopularityThreashold = ps.highlightHighPopularityThreashold;
+			}
+
+			if (ps.highlightExcludeEmojis !== undefined) {
 				set.highlightExcludeEmojis = ps.highlightExcludeEmojis;
 			}
 

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<MkCwButton v-model="showContent" :text="appearNote.text" :renote="appearNote.renote" :files="appearNote.files" :poll="appearNote.poll" style="margin: 4px 0;"/>
 				</p>
 				<div v-show="appearNote.cw == null || showContent" :class="[{ [$style.contentCollapsed]: collapsed }]">
-					<div :class="[$style.text, {[$style.akafav]:(featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]" :style="favstarColorVars">
+					<div :class="[$style.text, {[$style.akafav]:(featured && prefer.r.enableFavstar.value && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && prefer.r.enableFavstar.value && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]" :style="favstarColorVars">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 						<MkA v-if="appearNote.replyId" :class="$style.replyIcon" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
 						<Mfm
@@ -273,19 +273,18 @@ const currentAntenna = inject<Ref<Misskey.entities.Antenna | null> | null>('curr
 
 let note = deepClone(props.note);
 
-
 const highlightPopularityThreshold = computed(() => {
 	return {
-		highPopularity: instance.highlightHighPopularityThreashold,
+		highPopularity: instance.highlightHighPopularityThreshold,
 		midPopularity: instance.highlightMidPopularityThreshold,
-	}
-})
+	};
+});
 
 const favstarColorVars = computed(() => {
-	if (!props.featured || !prefer.s.enableFavstar) return undefined;
+	if (!props.featured || !prefer.r.enableFavstar.value) return undefined;
 	return {
-		'--MI-favstarAka': store.s.darkMode ? prefer.s.favstarDarkAka : prefer.s.favstarLightAka,
-		'--MI-favstarAo': store.s.darkMode ? prefer.s.favstarDarkAo : prefer.s.favstarLightAo,
+		'--MI-favstarAka': store.r.darkMode.value ? prefer.r.favstarDarkAka.value : prefer.r.favstarLightAka.value,
+		'--MI-favstarAo': store.r.darkMode.value ? prefer.r.favstarDarkAo.value : prefer.r.favstarLightAo.value,
 	};
 });
 // plugin

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<MkCwButton v-model="showContent" :text="appearNote.text" :renote="appearNote.renote" :files="appearNote.files" :poll="appearNote.poll" style="margin: 4px 0;"/>
 				</p>
 				<div v-show="appearNote.cw == null || showContent" :class="[{ [$style.contentCollapsed]: collapsed }]">
-					<div :class="[$style.text, {[$style.akafav]:(featured && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]">
+					<div :class="[$style.text, {[$style.akafav]:(featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 						<MkA v-if="appearNote.replyId" :class="$style.replyIcon" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
 						<Mfm

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<MkCwButton v-model="showContent" :text="appearNote.text" :renote="appearNote.renote" :files="appearNote.files" :poll="appearNote.poll" style="margin: 4px 0;"/>
 				</p>
 				<div v-show="appearNote.cw == null || showContent" :class="[{ [$style.contentCollapsed]: collapsed }]">
-					<div :class="[$style.text, {[$style.akafav]:(featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]">
+					<div :class="[$style.text, {[$style.akafav]:(featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && prefer.s.enableFavstar && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]" :style="favstarColorVars">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 						<MkA v-if="appearNote.replyId" :class="$style.replyIcon" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
 						<Mfm
@@ -241,6 +241,7 @@ import { isEnabledUrlPreview } from '@/utility/url-preview.js';
 import { focusPrev, focusNext } from '@/utility/focus.js';
 import { getAppearNote } from '@/utility/get-appear-note.js';
 import { prefer } from '@/preferences.js';
+import { store } from '@/store.js';
 import { getPluginHandlers } from '@/plugin.js';
 import { DI } from '@/di.js';
 import { globalEvents } from '@/events.js';
@@ -279,6 +280,14 @@ const highlightPopularityThreshold = computed(() => {
 		midPopularity: instance.highlightMidPopularityThreshold,
 	}
 })
+
+const favstarColorVars = computed(() => {
+	if (!props.featured || !prefer.s.enableFavstar) return undefined;
+	return {
+		'--MI-favstarAka': store.s.darkMode ? prefer.s.favstarDarkAka : prefer.s.favstarLightAka,
+		'--MI-favstarAo': store.s.darkMode ? prefer.s.favstarDarkAo : prefer.s.favstarLightAo,
+	};
+});
 // plugin
 const noteViewInterruptors = getPluginHandlers('note_view_interruptor');
 const hideByPlugin = ref(false);
@@ -738,11 +747,11 @@ function emitUpdReaction(emoji: string, delta: number) {
 
 	.akafav {
 		font-size: 2rem;
-		color: #f7796c;
+		color: var(--MI-favstarAka, #f7796c);
 	}
 	.aofav {
 		font-size: 1.5rem;
-		color: rgb(68, 164, 193);
+		color: var(--MI-favstarAo, #44a4c1);
 	}
 
 	&:focus-visible {

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -64,7 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<MkCwButton v-model="showContent" :text="appearNote.text" :renote="appearNote.renote" :files="appearNote.files" :poll="appearNote.poll" style="margin: 4px 0;"/>
 				</p>
 				<div v-show="appearNote.cw == null || showContent" :class="[{ [$style.contentCollapsed]: collapsed }]">
-					<div :class="$style.text">
+					<div :class="[$style.text, {[$style.akafav]:(featured && note.reactionCount >= highlightPopularityThreshold.highPopularity ), [$style.aofav]: featured && note.reactionCount >= highlightPopularityThreshold.midPopularity && note.reactionCount < highlightPopularityThreshold.highPopularity }]">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 						<MkA v-if="appearNote.replyId" :class="$style.replyIcon" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
 						<Mfm
@@ -244,14 +244,17 @@ import { prefer } from '@/preferences.js';
 import { getPluginHandlers } from '@/plugin.js';
 import { DI } from '@/di.js';
 import { globalEvents } from '@/events.js';
+import { instance } from '@/instance.js';
 
 const props = withDefaults(defineProps<{
 	note: Misskey.entities.Note;
 	pinned?: boolean;
 	mock?: boolean;
 	withHardMute?: boolean;
+	featured?: boolean;
 }>(), {
 	mock: false,
+	featured: false,
 });
 
 provide(DI.mock, props.mock);
@@ -269,6 +272,13 @@ const currentAntenna = inject<Ref<Misskey.entities.Antenna | null> | null>('curr
 
 let note = deepClone(props.note);
 
+
+const highlightPopularityThreshold = computed(() => {
+	return {
+		highPopularity: instance.highlightHighPopularityThreashold,
+		midPopularity: instance.highlightMidPopularityThreshold,
+	}
+})
 // plugin
 const noteViewInterruptors = getPluginHandlers('note_view_interruptor');
 const hideByPlugin = ref(false);
@@ -725,6 +735,15 @@ function emitUpdReaction(emoji: string, delta: number) {
 	font-size: 1.05em;
 	overflow: clip;
 	contain: content;
+
+	.akafav {
+		font-size: 2rem;
+		color: #f7796c;
+	}
+	.aofav {
+		font-size: 1.5rem;
+		color: rgb(68, 164, 193);
+	}
 
 	&:focus-visible {
 		outline: none;

--- a/packages/frontend/src/components/MkNotesTimeline.vue
+++ b/packages/frontend/src/components/MkNotesTimeline.vue
@@ -20,18 +20,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<span style="height: 1em; width: 1px; background: var(--MI_THEME-divider);"></span>
 						<span>{{ getSeparatorInfo(paginator.items.value[i - 1].createdAt, note.createdAt)?.nextText }} <i class="ti ti-chevron-down"></i></span>
 					</div>
-					<MkNote :class="$style.note" :note="note" :withHardMute="true"/>
+					<MkNote :class="$style.note" :note="note" :featured="featured" :withHardMute="true"/>
 					<div v-if="note._shouldInsertAd_" :class="$style.ad">
 						<MkAd :preferForms="['horizontal', 'horizontal-big']"/>
 					</div>
 				</div>
 				<div v-else-if="note._shouldInsertAd_" :class="{ '_gaps': !noGap }" :data-scroll-anchor="note.id">
-					<MkNote :class="$style.note" :note="note" :withHardMute="true"/>
+					<MkNote :class="$style.note" :note="note" :featured="featured" :withHardMute="true"/>
 					<div :class="$style.ad">
 						<MkAd :preferForms="['horizontal', 'horizontal-big']"/>
 					</div>
 				</div>
-				<MkNote v-else :class="$style.note" :note="note" :withHardMute="true" :data-scroll-anchor="note.id"/>
+				<MkNote v-else :class="$style.note" :note="note" :featured="featured" :withHardMute="true" :data-scroll-anchor="note.id"/>
 			</template>
 		</div>
 	</template>
@@ -51,12 +51,14 @@ import { isSeparatorNeeded, getSeparatorInfo } from '@/utility/timeline-date-sep
 const props = withDefaults(defineProps<MkPaginationOptions & {
 	paginator: T;
 	noGap?: boolean;
+	featured?: boolean;
 }>(), {
 	autoLoad: true,
 	direction: 'down',
 	pullToRefresh: true,
 	withControl: true,
 	forceDisableInfiniteScroll: false,
+	featured: false,
 });
 
 useGlobalEvent('noteDeleted', (noteId) => {

--- a/packages/frontend/src/instance.ts
+++ b/packages/frontend/src/instance.ts
@@ -27,11 +27,10 @@ if (providedAt > cachedAt) {
 
 // TODO: instanceをリアクティブにするかは再考の余地あり
 
-
 type HighlightPopularityThreshold = {
 	highlightMidPopularityThreshold: number;
-	highlightHighPopularityThreashold: number;
-}
+	highlightHighPopularityThreshold: number;
+};
 
 export const instance: Misskey.entities.MetaDetailed & HighlightPopularityThreshold = reactive(cachedMeta ?? {});
 

--- a/packages/frontend/src/instance.ts
+++ b/packages/frontend/src/instance.ts
@@ -27,7 +27,13 @@ if (providedAt > cachedAt) {
 
 // TODO: instanceをリアクティブにするかは再考の余地あり
 
-export const instance: Misskey.entities.MetaDetailed = reactive(cachedMeta ?? {});
+
+type HighlightPopularityThreshold = {
+	highlightMidPopularityThreshold: number;
+	highlightHighPopularityThreashold: number;
+}
+
+export const instance: Misskey.entities.MetaDetailed & HighlightPopularityThreshold = reactive(cachedMeta ?? {});
 
 export async function fetchInstance(force = false): Promise<Misskey.entities.MetaDetailed> {
 	if (!force) {

--- a/packages/frontend/src/pages/admin/settings.vue
+++ b/packages/frontend/src/pages/admin/settings.vue
@@ -368,6 +368,41 @@ SPDX-License-Identifier: AGPL-3.0-only
 					</MkFolder>
 				</SearchMarker>
 
+				<SearchMarker :keywords="['highlight', 'favstar']">
+					<MkFolder>
+						<template #icon><SearchIcon><i class="ti ti-ghost"></i></SearchIcon></template>
+						<template #label><SearchLabel>みつける＞ハイライトの調整</SearchLabel></template>
+
+						<div class="_gaps">
+							<MkInfo>リアクションしたときに見つける＞ハイライトの採用される確率は、大規模サーバーにおいてパフォーマンスへの影響を考慮してデフォルト30%です。（つまり、70%のリアクションはカウントに影響しません）</MkInfo>
+
+							<MkKeyValue>
+								<template #key>ハイライトに採用される確率</template>
+								<template #value><MkInput v-model.number="infoForm.state.highlightRateFactor" :min="0" :max="100" placeholder="30"/></template>
+							</MkKeyValue>
+
+							<MkKeyValue>
+								<template #key>ハイライトの青ふぁぼ</template>
+								<template #value><MkInput v-model.number="infoForm.state.highlightMidPopularityThreshold"/></template>
+							</MkKeyValue>
+
+							<MkKeyValue>
+								<template #key>ハイライトの赤ふぁぼ</template>
+								<template #value><MkInput v-model.number="infoForm.state.highlightHighPopularityThreashold"/></template>
+							</MkKeyValue>
+
+							<MkKeyValue>
+								<template #key>ハイライトのから除外する絵文字</template>
+								<template #value>
+									<MkTextarea v-model="infoForm.state.highlightExcludeEmojis" :mfmAutocomplete="['emoji']" :mfmPreview="true"/>
+								</template>
+							</MkKeyValue>
+
+							<MkFormFooter :form="infoForm"/>
+						</div>
+					</MkFolder>
+				</SearchMarker>
+
 				<MkButton primary @click="openSetupWizard">
 					Open setup wizard
 				</MkButton>
@@ -394,6 +429,7 @@ import MkFolder from '@/components/MkFolder.vue';
 import { useForm } from '@/composables/use-form.js';
 import MkFormFooter from '@/components/MkFormFooter.vue';
 import MkRadios from '@/components/MkRadios.vue';
+import MkKeyValue from '@/components/MkKeyValue.vue';
 
 const meta = await misskeyApi('admin/meta');
 
@@ -410,6 +446,10 @@ const infoForm = useForm({
 	inquiryUrl: meta.inquiryUrl ?? '',
 	repositoryUrl: meta.repositoryUrl ?? '',
 	impressumUrl: meta.impressumUrl ?? '',
+	highlightRateFactor: meta.highlightRateFactor ?? 30,
+	highlightMidPopularityThreshold: meta.highlightMidPopularityThreshold ?? 3,
+	highlightHighPopularityThreashold: meta.highlightHighPopularityThreashold ?? 5,
+	highlightExcludeEmojis: meta.highlightExcludeEmojis,
 }, async (state) => {
 	await os.apiWithDialog('admin/update-meta', {
 		name: state.name,
@@ -422,6 +462,11 @@ const infoForm = useForm({
 		inquiryUrl: state.inquiryUrl,
 		repositoryUrl: state.repositoryUrl,
 		impressumUrl: state.impressumUrl,
+		highlightRateFactor: state.highlightRateFactor,
+		highlightMidPopularityThreshold: state.highlightMidPopularityThreshold,
+		highlightHighPopularityThreashold: state.highlightHighPopularityThreashold ?? 5,
+		highlightExcludeEmojis: state.highlightExcludeEmojis,
+
 	});
 	fetchInstance(true);
 });

--- a/packages/frontend/src/pages/admin/settings.vue
+++ b/packages/frontend/src/pages/admin/settings.vue
@@ -378,17 +378,17 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 							<MkKeyValue>
 								<template #key>ハイライトに採用される確率</template>
-								<template #value><MkInput v-model.number="infoForm.state.highlightRateFactor" :min="0" :max="100" placeholder="30"/></template>
+								<template #value><MkInput v-model.number="infoForm.state.highlightRateFactor" type="number" :min="0" :max="100" placeholder="30"/></template>
 							</MkKeyValue>
 
 							<MkKeyValue>
 								<template #key>ハイライトの青ふぁぼ</template>
-								<template #value><MkInput v-model.number="infoForm.state.highlightMidPopularityThreshold"/></template>
+								<template #value><MkInput v-model.number="infoForm.state.highlightMidPopularityThreshold" type="number"/></template>
 							</MkKeyValue>
 
 							<MkKeyValue>
 								<template #key>ハイライトの赤ふぁぼ</template>
-								<template #value><MkInput v-model.number="infoForm.state.highlightHighPopularityThreashold"/></template>
+								<template #value><MkInput v-model.number="infoForm.state.highlightHighPopularityThreshold" type="number"/></template>
 							</MkKeyValue>
 
 							<MkKeyValue>
@@ -448,7 +448,7 @@ const infoForm = useForm({
 	impressumUrl: meta.impressumUrl ?? '',
 	highlightRateFactor: meta.highlightRateFactor ?? 30,
 	highlightMidPopularityThreshold: meta.highlightMidPopularityThreshold ?? 3,
-	highlightHighPopularityThreashold: meta.highlightHighPopularityThreashold ?? 5,
+	highlightHighPopularityThreshold: meta.highlightHighPopularityThreshold ?? 5,
 	highlightExcludeEmojis: meta.highlightExcludeEmojis,
 }, async (state) => {
 	await os.apiWithDialog('admin/update-meta', {
@@ -464,7 +464,7 @@ const infoForm = useForm({
 		impressumUrl: state.impressumUrl,
 		highlightRateFactor: state.highlightRateFactor,
 		highlightMidPopularityThreshold: state.highlightMidPopularityThreshold,
-		highlightHighPopularityThreashold: state.highlightHighPopularityThreashold ?? 5,
+		highlightHighPopularityThreshold: state.highlightHighPopularityThreshold ?? 5,
 		highlightExcludeEmojis: state.highlightExcludeEmojis,
 
 	});

--- a/packages/frontend/src/pages/explore.featured.vue
+++ b/packages/frontend/src/pages/explore.featured.vue
@@ -14,8 +14,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 		style="margin-bottom: var(--MI-margin);"
 	>
 	</MkTab>
-	<MkNotesTimeline v-if="tab === 'notes'" :paginator="paginatorForNotes"/>
-	<MkNotesTimeline v-else-if="tab === 'polls'" :paginator="paginatorForPolls"/>
+	<MkNotesTimeline v-if="tab === 'notes'" :featured="true" :paginator="paginatorForNotes"/>
+	<MkNotesTimeline v-else-if="tab === 'polls'" :featured="true" :paginator="paginatorForPolls"/>
 </div>
 </template>
 

--- a/packages/frontend/src/pages/explore.featured.vue
+++ b/packages/frontend/src/pages/explore.featured.vue
@@ -6,6 +6,20 @@ SPDX-License-Identifier: AGPL-3.0-only
 <template>
 <div class="_spacer" style="--MI_SPACER-w: 800px;">
 	<MkSwitch v-model="enableFavstar" style="margin-bottom: var(--MI-margin);">ふぁぼったー</MkSwitch>
+	<div v-if="enableFavstar" :class="$style.favstarColors">
+		<MkRadios v-model="favstarLightAo" :options="lightAoOptions">
+			<template #label>ライトモードの青ふぁぼ</template>
+		</MkRadios>
+		<MkRadios v-model="favstarLightAka" :options="lightAkaOptions">
+			<template #label>ライトモードの赤ふぁぼ</template>
+		</MkRadios>
+		<MkRadios v-model="favstarDarkAo" :options="darkAoOptions">
+			<template #label>ダークモードの青ふぁぼ</template>
+		</MkRadios>
+		<MkRadios v-model="favstarDarkAka" :options="darkAkaOptions">
+			<template #label>ダークモードの赤ふぁぼ</template>
+		</MkRadios>
+	</div>
 	<MkTab
 		v-model="tab"
 		:tabs="[
@@ -25,11 +39,40 @@ import { markRaw, ref } from 'vue';
 import MkNotesTimeline from '@/components/MkNotesTimeline.vue';
 import MkTab from '@/components/MkTab.vue';
 import MkSwitch from '@/components/MkSwitch.vue';
+import MkRadios from '@/components/MkRadios.vue';
 import { i18n } from '@/i18n.js';
 import { Paginator } from '@/utility/paginator.js';
 import { prefer } from '@/preferences.js';
 
 const enableFavstar = prefer.model('enableFavstar');
+const favstarLightAo = prefer.model('favstarLightAo');
+const favstarLightAka = prefer.model('favstarLightAka');
+const favstarDarkAo = prefer.model('favstarDarkAo');
+const favstarDarkAka = prefer.model('favstarDarkAka');
+
+const withSwatch = (entries: { value: string; label: string }[]) =>
+	entries.map(e => ({ ...e, labelStyle: { color: e.value, fontWeight: 'bold' } }));
+
+const lightAoOptions = withSwatch([
+	{ value: '#44a4c1', label: '既定' },
+	{ value: '#5db0da', label: 'Rainy' },
+	{ value: '#008cff', label: 'Vivid' },
+]);
+const lightAkaOptions = withSwatch([
+	{ value: '#f7796c', label: '既定' },
+	{ value: '#dd2e44', label: 'Love' },
+	{ value: '#db6072', label: 'Cherry' },
+]);
+const darkAoOptions = withSwatch([
+	{ value: '#44a4c1', label: '既定' },
+	{ value: '#47bfe8', label: 'Ice' },
+	{ value: '#70c0e8', label: 'Future' },
+]);
+const darkAkaOptions = withSwatch([
+	{ value: '#f7796c', label: '既定' },
+	{ value: '#ff5975', label: 'Cherry' },
+	{ value: '#ff6652', label: 'Astro' },
+]);
 
 const paginatorForNotes = markRaw(new Paginator('notes/featured', {
 	limit: 10,
@@ -45,3 +88,12 @@ const paginatorForPolls = markRaw(new Paginator('notes/polls/recommendation', {
 
 const tab = ref<'notes' | 'polls'>('notes');
 </script>
+
+<style lang="scss" module>
+.favstarColors {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	margin-bottom: var(--MI-margin);
+}
+</style>

--- a/packages/frontend/src/pages/explore.featured.vue
+++ b/packages/frontend/src/pages/explore.featured.vue
@@ -6,20 +6,43 @@ SPDX-License-Identifier: AGPL-3.0-only
 <template>
 <div class="_spacer" style="--MI_SPACER-w: 800px;">
 	<MkSwitch v-model="enableFavstar" style="margin-bottom: var(--MI-margin);">ふぁぼったー</MkSwitch>
-	<div v-if="enableFavstar" :class="$style.favstarColors">
-		<MkRadios v-model="favstarLightAo" :options="lightAoOptions">
-			<template #label>ライトモードの青ふぁぼ</template>
-		</MkRadios>
-		<MkRadios v-model="favstarLightAka" :options="lightAkaOptions">
-			<template #label>ライトモードの赤ふぁぼ</template>
-		</MkRadios>
-		<MkRadios v-model="favstarDarkAo" :options="darkAoOptions">
-			<template #label>ダークモードの青ふぁぼ</template>
-		</MkRadios>
-		<MkRadios v-model="favstarDarkAka" :options="darkAkaOptions">
-			<template #label>ダークモードの赤ふぁぼ</template>
-		</MkRadios>
-	</div>
+
+	<MkFolder v-if="enableFavstar" style="margin-bottom: var(--MI-margin);">
+		<template #icon><i class="ti ti-palette"></i></template>
+		<template #label>ふぁぼったーの色</template>
+		<div :class="$style.grid2x2">
+			<div :class="$style.gridCell" :style="lightCellStyle">
+				<div :class="$style.gridHead">ライトモード</div>
+				<div :class="$style.gridRow">
+					<span :class="$style.kindLabel">青ふぁぼ</span>
+					<div :class="$style.swatchRow">
+						<button v-for="o in lightAoOptions" :key="o.value" type="button" :class="[$style.swatch, { [$style.swatchSelected]: favstarLightAo === o.value }]" :style="{ background: o.value }" :title="o.label" @click="favstarLightAo = o.value"></button>
+					</div>
+				</div>
+				<div :class="$style.gridRow">
+					<span :class="$style.kindLabel">赤ふぁぼ</span>
+					<div :class="$style.swatchRow">
+						<button v-for="o in lightAkaOptions" :key="o.value" type="button" :class="[$style.swatch, { [$style.swatchSelected]: favstarLightAka === o.value }]" :style="{ background: o.value }" :title="o.label" @click="favstarLightAka = o.value"></button>
+					</div>
+				</div>
+			</div>
+			<div :class="$style.gridCell" :style="darkCellStyle">
+				<div :class="$style.gridHead">ダークモード</div>
+				<div :class="$style.gridRow">
+					<span :class="$style.kindLabel">青ふぁぼ</span>
+					<div :class="$style.swatchRow">
+						<button v-for="o in darkAoOptions" :key="o.value" type="button" :class="[$style.swatch, { [$style.swatchSelected]: favstarDarkAo === o.value }]" :style="{ background: o.value }" :title="o.label" @click="favstarDarkAo = o.value"></button>
+					</div>
+				</div>
+				<div :class="$style.gridRow">
+					<span :class="$style.kindLabel">赤ふぁぼ</span>
+					<div :class="$style.swatchRow">
+						<button v-for="o in darkAkaOptions" :key="o.value" type="button" :class="[$style.swatch, { [$style.swatchSelected]: favstarDarkAka === o.value }]" :style="{ background: o.value }" :title="o.label" @click="favstarDarkAka = o.value"></button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</MkFolder>
 	<MkTab
 		v-model="tab"
 		:tabs="[
@@ -35,14 +58,35 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { markRaw, ref } from 'vue';
+import { computed, markRaw, ref } from 'vue';
+import baseLight from '@@/themes/_light.json5';
+import baseDark from '@@/themes/_dark.json5';
+import defaultLightTheme from '@@/themes/l-light.json5';
+import defaultDarkTheme from '@@/themes/d-green-lime.json5';
+import type { Theme } from '@@/js/theme.js';
+import { compile } from '@@/js/theme.js';
 import MkNotesTimeline from '@/components/MkNotesTimeline.vue';
 import MkTab from '@/components/MkTab.vue';
 import MkSwitch from '@/components/MkSwitch.vue';
-import MkRadios from '@/components/MkRadios.vue';
+import MkFolder from '@/components/MkFolder.vue';
 import { i18n } from '@/i18n.js';
 import { Paginator } from '@/utility/paginator.js';
 import { prefer } from '@/preferences.js';
+import { deepClone } from '@/utility/clone.js';
+
+type ColorOption = { value: string; label: string };
+
+function compileWithBase(theme: Theme): Record<string, string> {
+	const t = deepClone(theme);
+	const base = [baseLight, baseDark].find(x => x.id === t.base);
+	if (base) t.props = Object.assign({}, base.props, t.props);
+	return compile(t);
+}
+
+const compiledLight = computed(() => compileWithBase(prefer.s.lightTheme ?? defaultLightTheme));
+const compiledDark = computed(() => compileWithBase(prefer.s.darkTheme ?? defaultDarkTheme));
+const lightCellStyle = computed(() => ({ background: compiledLight.value.bg, color: compiledLight.value.fg }));
+const darkCellStyle = computed(() => ({ background: compiledDark.value.bg, color: compiledDark.value.fg }));
 
 const enableFavstar = prefer.model('enableFavstar');
 const favstarLightAo = prefer.model('favstarLightAo');
@@ -50,29 +94,26 @@ const favstarLightAka = prefer.model('favstarLightAka');
 const favstarDarkAo = prefer.model('favstarDarkAo');
 const favstarDarkAka = prefer.model('favstarDarkAka');
 
-const withSwatch = (entries: { value: string; label: string }[]) =>
-	entries.map(e => ({ ...e, labelStyle: { color: e.value, fontWeight: 'bold' } }));
-
-const lightAoOptions = withSwatch([
+const lightAoOptions: ColorOption[] = [
 	{ value: '#44a4c1', label: '既定' },
-	{ value: '#5db0da', label: 'Rainy' },
+	{ value: '#2962ff', label: 'Royal' },
 	{ value: '#008cff', label: 'Vivid' },
-]);
-const lightAkaOptions = withSwatch([
+];
+const lightAkaOptions: ColorOption[] = [
 	{ value: '#f7796c', label: '既定' },
 	{ value: '#dd2e44', label: 'Love' },
 	{ value: '#db6072', label: 'Cherry' },
-]);
-const darkAoOptions = withSwatch([
+];
+const darkAoOptions: ColorOption[] = [
 	{ value: '#44a4c1', label: '既定' },
-	{ value: '#47bfe8', label: 'Ice' },
+	{ value: '#3d6bff', label: 'Royal' },
 	{ value: '#70c0e8', label: 'Future' },
-]);
-const darkAkaOptions = withSwatch([
+];
+const darkAkaOptions: ColorOption[] = [
 	{ value: '#f7796c', label: '既定' },
 	{ value: '#ff5975', label: 'Cherry' },
-	{ value: '#ff6652', label: 'Astro' },
-]);
+	{ value: '#ff1f3a', label: 'Blaze' },
+];
 
 const paginatorForNotes = markRaw(new Paginator('notes/featured', {
 	limit: 10,
@@ -90,10 +131,66 @@ const tab = ref<'notes' | 'polls'>('notes');
 </script>
 
 <style lang="scss" module>
-.favstarColors {
+.grid2x2 {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 12px;
+}
+
+@container (max-width: 500px) {
+	.grid2x2 {
+		grid-template-columns: 1fr;
+	}
+}
+
+.gridCell {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
-	margin-bottom: var(--MI-margin);
+	gap: 8px;
+	padding: 10px;
+	border-radius: 8px;
+}
+
+.gridHead {
+	font-size: 0.85em;
+	opacity: 0.7;
+}
+
+.gridRow {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-height: 32px;
+}
+
+.kindLabel {
+	font-size: 0.9em;
+	min-width: 5.5em;
+}
+
+.swatchRow {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.swatch {
+	width: 26px;
+	height: 26px;
+	border-radius: 50%;
+	border: 2px solid transparent;
+	padding: 0;
+	cursor: pointer;
+	box-shadow: 0 0 0 1px rgba(0,0,0,0.1) inset;
+	transition: transform 0.1s, border-color 0.1s;
+}
+
+.swatch:hover {
+	transform: scale(1.1);
+}
+
+.swatchSelected {
+	border-color: var(--MI_THEME-accent);
+	box-shadow: 0 0 0 2px var(--MI_THEME-accent), 0 0 0 1px rgba(0,0,0,0.1) inset;
 }
 </style>

--- a/packages/frontend/src/pages/explore.featured.vue
+++ b/packages/frontend/src/pages/explore.featured.vue
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div class="_spacer" style="--MI_SPACER-w: 800px;">
+	<MkSwitch v-model="enableFavstar" style="margin-bottom: var(--MI-margin);">ふぁぼったー</MkSwitch>
 	<MkTab
 		v-model="tab"
 		:tabs="[
@@ -23,8 +24,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 import { markRaw, ref } from 'vue';
 import MkNotesTimeline from '@/components/MkNotesTimeline.vue';
 import MkTab from '@/components/MkTab.vue';
+import MkSwitch from '@/components/MkSwitch.vue';
 import { i18n } from '@/i18n.js';
 import { Paginator } from '@/utility/paginator.js';
+import { prefer } from '@/preferences.js';
+
+const enableFavstar = prefer.model('enableFavstar');
 
 const paginatorForNotes = markRaw(new Paginator('notes/featured', {
 	limit: 10,

--- a/packages/frontend/src/preferences/def.ts
+++ b/packages/frontend/src/preferences/def.ts
@@ -225,6 +225,9 @@ export const PREF_DEF = definePreferences({
 	showReactionsCount: {
 		default: false,
 	},
+	enableFavstar: {
+		default: true,
+	},
 	enableQuickAddMfmFunction: {
 		default: false,
 	},

--- a/packages/frontend/src/preferences/def.ts
+++ b/packages/frontend/src/preferences/def.ts
@@ -228,6 +228,18 @@ export const PREF_DEF = definePreferences({
 	enableFavstar: {
 		default: true,
 	},
+	favstarLightAo: {
+		default: '#44a4c1',
+	},
+	favstarLightAka: {
+		default: '#f7796c',
+	},
+	favstarDarkAo: {
+		default: '#44a4c1',
+	},
+	favstarDarkAka: {
+		default: '#f7796c',
+	},
 	enableQuickAddMfmFunction: {
 		default: false,
 	},

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -9561,6 +9561,10 @@ export interface operations {
                         remoteNotesCleaningExpiryDaysForEachNotes: number;
                         remoteNotesCleaningMaxProcessingDurationInMinutes: number;
                         showRoleBadgesOfRemoteUsers: boolean;
+                        highlightRateFactor: number;
+                        highlightMidPopularityThreshold: number;
+                        highlightHighPopularityThreshold: number;
+                        highlightExcludeEmojis: string;
                     };
                 };
             };
@@ -13013,6 +13017,10 @@ export interface operations {
                     remoteNotesCleaningExpiryDaysForEachNotes?: number;
                     remoteNotesCleaningMaxProcessingDurationInMinutes?: number;
                     showRoleBadgesOfRemoteUsers?: boolean;
+                    highlightRateFactor?: number;
+                    highlightMidPopularityThreshold?: number;
+                    highlightHighPopularityThreshold?: number;
+                    highlightExcludeEmojis?: string;
                 };
             };
         };


### PR DESCRIPTION
**Claude finished @fruitriin's task in 1m 37s** —— [View job](https://github.com/fruitriin/misskey/actions/runs/26702725926)

---
### PR本文の作成が完了しました

- [x] 変更ファイルを読み込んで機能を把握する
- [x] PR本文を作成する

---

以下をPR本文としてご利用ください。

---

## ふぁぼったー (favstar) 機能の追加

「みつける」タイムラインにおいて、リアクション数に応じてノートを色付けで強調表示する **ふぁぼったー** 機能を追加します。

### 概要

「みつける」画面に表示されるノートを、リアクション数のしきい値に基づいて視覚的に色分けします。

- **赤ふぁぼ (akafav)**: 高人気しきい値以上のノートを赤色でハイライト
- **青ふぁぼ (aofav)**: 中人気しきい値以上・高人気しきい値未満のノートを青色でハイライト

### 変更内容

#### バックエンド
- **`Meta.ts`**: ハイライト集計パラメータを追加
  - `highlightRateFactor` (デフォルト: 30)
  - `highlightMidPopularityThreshold` (デフォルト: 3)
  - `highlightHighPopularityThreashold` (デフォルト: 5)
  - `highlightExcludeEmojis`: 集計から除外する絵文字リスト（改行区切り）
- **`ReactionService.ts`**: 除外絵文字を考慮したリアクション数集計に対応
- **`MetaEntityService.ts`**: 上記パラメータをインスタンス情報 API で公開
- **`admin/meta.ts` / `admin/update-meta.ts`**: 管理者向け設定 API を追加

#### フロントエンド
- **`MkNote.vue`**: `featured` プロップが有効かつユーザーがふぁぼったーを有効にしている場合、リアクション数に応じて `.akafav` / `.aofav` クラスを付与。CSS変数 `--MI-favstarAka` / `--MI-favstarAo` で色をカスタマイズ可能
- **`MkNotesTimeline.vue`**: `featured` プロップを追加
- **`instance.ts`**: ハイライトしきい値情報をインスタンス設定として取得
- **`admin/settings.vue`**: 管理画面にハイライト設定セクションを追加（しきい値・除外絵文字の設定）
- **`explore.featured.vue`**: 「みつける」画面にふぁぼったートグルと色選択UI（ライト/ダークモード × 青/赤の4択）を追加
- **`preferences/def.ts`**: 以下のユーザー設定を追加
  - `enableFavstar`: ふぁぼったーの有効/無効
  - `favstarLightAo` / `favstarLightAka`: ライトモード時の青/赤色
  - `favstarDarkAo` / `favstarDarkAka`: ダークモード時の青/赤色

### 既知の課題

- 色設定のUIが「みつける」画面に直接配置されており、スペースを取りすぎる（設定画面への移動を検討中）
- 色変更が画面にリアルタイム反映されない問題あり（未調査）

### マイグレーション

`Meta` テーブルに新しいカラムを追加するため、DBマイグレーションが必要です。