### PR TITLE
docs: README/統合スクリプトを mistems-main(MISTEMS.94)の最新状況に同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://github.com/mistems/mistems/pulls
 - ノート周辺
   - リノート先/元のチャンネル名を表示  
   - リアクションのビューアに読み仮名などを表示
+  - MkNoteDetailed で返信を読み込む
 
 - リアクションピッカー
   - 検索がひらがな/カタカナを区別しなくなる
@@ -39,12 +40,38 @@ https://github.com/mistems/mistems/pulls
   - リアクションがたくさんついたノートは青ふぁぼになったり赤ふぁぼになったりする
   - 何個で色が変わるかはコンパネ＞全般から設定すること
 
+- ふぁぼすたー（favstar）
+  - よくふぁぼ/リアクションされたノートを感じられる機能
+
+- タイムマシン（実験的）
+  - 過去のタイムラインをさかのぼる機能
+
+- MkPages
+  - エディターを拡張
+- ドラッグアンドドロップ
+  - スマホでの操作に対応 + アニメーション
+
 - 接続が再開したとき「サーバーから切断されました」のメッセージを消す
 
 - 絵文字管理画面に絵文字管理画面（グリッド）を先行導入
 
 - ショートカットキー
   - h でショートカットキーヘルプ
+
+- ハッシュタグでミュートできるようにする
+
+- 正常系のログをデバッグレベルに落とす（ログがうるさいのを抑える）
+
+- バグ修正
+  - FTTL（ファンアウトタイムライン）の歯抜けバグを修正
+  - 通知の残カウントがおかしくなるバグを修正
+  - 添付ファイルのエンコーディングがSJISになるバグを修正
+  - エラー画面で操作不能になることがあるのを修正
+  - すべてのアカウントからログアウトされる問題を修正
+
+- その他
+  - clipへのノート登録レートリミットを 20→100 へ緩和
+  - Claude Code の GitHub Workflow を追加（Issue, PR で Claude が反応）
 
 # 開発者向けドキュメント
 ## MISTEMSの作り方
@@ -93,12 +120,6 @@ end
 git switch mistems-main
 git reset origin/develop --hard
 
-# MkPostFormの宛先にチャンネルを追加, 翻訳を追加 swap-CW
-# チャンネルの既読を同期, registory-item endpointを追加 router.definition, main-boot
-# 追加, MkHelp, 
-git merge --squash  riin/mkPostFormExtend # チャンネル既読の同期を統合
-git commit -a -m "投稿機能周の拡張"
-
 git merge --squash riin/channelIndex 
 git commit -a -m "チャンネルだいたいぜんぶみる" # フォローとお気に入りの説明を統合
 git merge --squash riin/mkNoteExtend 
@@ -139,23 +160,52 @@ git commit -a -m "無名のユーザーからの通知を拒否する(MisskeyIO/
 git merge --squash riin/annoy-logs-goneto-debuglevel
 git commit -a -m "正常系ログをデバッグレベルに落とす"
 
+git merge --squash riin/fix/notification-unread-count
+git commit -a -m "通知の残カウントバグを直す"
+
+# MkPagesエディターの拡張 + ドラッグアンドドロップのスマホ対応・アニメーション
+git merge --squash riin/release/mkPages-mkDraggable
+git commit -a -m "MkPagesエディター拡張/ドラッグアンドドロップのスマホ拡張とアニメーション"
+
 git merge --squash riin/add-claude-github-actions-1762310148415
 git commit -a -m "Add Claude Code GitHub Workflow"
-# コンフリクトしたので取り込んでない
-# git merge --squash riin/favstar &&\
-# git commit -a -m "ふぁぼすたーを感じる機能" &&\
 
+# ファンアウトタイムラインの歯抜けバグ修正
+git merge --squash riin/fix/fanout-timeline-redis-gap
+git commit -a -m "FTTLの歯抜けバグ修正"
+
+# 以前はコンフリクトで取り込めなかったが release/FavstarAndTimemachine で統合
+git merge --squash riin/release/FavstarAndTimemachine
+git commit -a -m "タイムマシンとふぁぼった"
+
+# 添付ファイルのエンコーディングがSJISになるバグ修正
+git merge --squash riin/fix-textfile-encode
+git commit -a -m "添付ファイルのエンコーディングがSJISになるバグの修正"
+
+# MkPostFormの宛先にチャンネルを追加, 翻訳を追加 swap-CW
+# チャンネルの既読を同期, registory-item endpointを追加 router.definition, main-boot
+# 追加, MkHelp, 
+git merge --squash riin/mkPostFormExtend # チャンネル既読の同期を統合
+git commit -a -m "投稿機能周の拡張"
+
+# エラー画面で操作不能になることがあるのを修正
+git merge --squash riin/fix/error-page-unhandled
+git commit -a -m "エラー画面で操作不能になることがあるのを修正"
+
+# 以下は機能ブランチではなく mistems-main 上で直接修正・コミットしている
+# - clipへのノート登録レートリミットを 20->100へ緩和
+# - すべてのアカウントからログアウトされる問題を修正
+# - mistems-main.build-misskey-js-with-types 再生成
+
+# まだ取り込んでいないもの
 # コンフリクトしたので取り込んでない
 # git merge --squash riin/safe-rss &&\
 # git commit -a -m "saferRSS" &&\
-
 # コンフリクトの修正が必要
-#git merge --squash riin/readble-message-ratelimitservice 
-#git commit -a -m "BRIEF_REQUEST_INTERVAL を人間に意味のあるメッセージにする" 
-# git merge --squash riin/timemachine
-# git commit -a -m "実験的.タイムマシン"
+# git merge --squash riin/readble-message-ratelimitservice 
+# git commit -a -m "BRIEF_REQUEST_INTERVAL を人間に意味のあるメッセージにする" 
 
-set MISVER 75
+set MISVER 94
 set file_path "package.json"
 # JSONからversionを取得 -MISTEMS.XX を追加した新しいバージョンを作成
 set current_version (jq -r '.version' $file_path)

--- a/main-統合.sh
+++ b/main-統合.sh
@@ -35,15 +35,9 @@ end
 git switch mistems-main
 git reset origin/develop --hard
 
-# MkPostFormの宛先にチャンネルを追加, 翻訳を追加 swap-CW
-# チャンネルの既読を同期, registory-item endpointを追加 router.definition, main-boot
-# 追加, MkHelp, 
-git merge --squash  riin/mkPostFormExtend # チャンネル既読の同期を統合
-git commit -a -m "投稿機能周の拡張"
-
-git merge --squash riin/channelIndex 
+git merge --squash riin/channelIndex
 git commit -a -m "チャンネルだいたいぜんぶみる" # フォローとお気に入りの説明を統合
-git merge --squash riin/mkNoteExtend 
+git merge --squash riin/mkNoteExtend
 git commit -a -m "MkNote拡張（チャンネルRenoteどこからきてどこへいくのか）"
 
 # ノートに表示されているリアクションにホバーしたときに出るやつ MkReactionsViewer.details.vue
@@ -81,23 +75,52 @@ git commit -a -m "無名のユーザーからの通知を拒否する(MisskeyIO/
 git merge --squash riin/annoy-logs-goneto-debuglevel
 git commit -a -m "正常系ログをデバッグレベルに落とす"
 
+git merge --squash riin/fix/notification-unread-count
+git commit -a -m "通知の残カウントバグを直す"
+
+# MkPagesエディターの拡張 + ドラッグアンドドロップのスマホ対応・アニメーション
+git merge --squash riin/release/mkPages-mkDraggable
+git commit -a -m "MkPagesエディター拡張/ドラッグアンドドロップのスマホ拡張とアニメーション"
+
 git merge --squash riin/add-claude-github-actions-1762310148415
 git commit -a -m "Add Claude Code GitHub Workflow"
-# コンフリクトしたので取り込んでない
-# git merge --squash riin/favstar &&\
-# git commit -a -m "ふぁぼすたーを感じる機能" &&\
 
+# ファンアウトタイムラインの歯抜けバグ修正
+git merge --squash riin/fix/fanout-timeline-redis-gap
+git commit -a -m "FTTLの歯抜けバグ修正"
+
+# 以前はコンフリクトで取り込めなかったが release/FavstarAndTimemachine で統合
+git merge --squash riin/release/FavstarAndTimemachine
+git commit -a -m "タイムマシンとふぁぼった"
+
+# 添付ファイルのエンコーディングがSJISになるバグ修正
+git merge --squash riin/fix-textfile-encode
+git commit -a -m "添付ファイルのエンコーディングがSJISになるバグの修正"
+
+# MkPostFormの宛先にチャンネルを追加, 翻訳を追加 swap-CW
+# チャンネルの既読を同期, registory-item endpointを追加 router.definition, main-boot
+# 追加, MkHelp,
+git merge --squash riin/mkPostFormExtend # チャンネル既読の同期を統合
+git commit -a -m "投稿機能周の拡張"
+
+# エラー画面で操作不能になることがあるのを修正
+git merge --squash riin/fix/error-page-unhandled
+git commit -a -m "エラー画面で操作不能になることがあるのを修正"
+
+# 以下は機能ブランチではなく mistems-main 上で直接修正・コミットしている
+# - clipへのノート登録レートリミットを 20->100へ緩和
+# - すべてのアカウントからログアウトされる問題を修正
+# - mistems-main.build-misskey-js-with-types 再生成
+
+# まだ取り込んでいないもの
 # コンフリクトしたので取り込んでない
 # git merge --squash riin/safe-rss &&\
 # git commit -a -m "saferRSS" &&\
-
 # コンフリクトの修正が必要
-#git merge --squash riin/readble-message-ratelimitservice 
-#git commit -a -m "BRIEF_REQUEST_INTERVAL を人間に意味のあるメッセージにする" 
-# git merge --squash riin/timemachine
-# git commit -a -m "実験的.タイムマシン"
+# git merge --squash riin/readble-message-ratelimitservice
+# git commit -a -m "BRIEF_REQUEST_INTERVAL を人間に意味のあるメッセージにする"
 
-set MISVER 75
+set MISVER 94
 set file_path "package.json"
 # JSONからversionを取得 -MISTEMS.XX を追加した新しいバージョンを作成
 set current_version (jq -r '.version' $file_path)


### PR DESCRIPTION
## 概要

`mistems-readme` の README と統合スクリプト（`main-統合.sh`）を、`mistems-main` の最新状況（**MISTEMS.94 / 2026.6.0**）に合わせて同期しました。README が古い状態（MISVER 75）のまま取り残されていたため、`mistems-main` のコミットログ（develop との差分）を正として更新しています。

## 変更点

### 変更点（機能一覧）に追記
- **タイムマシン（実験的）** / **ふぁぼすたー（favstar）** — 旧スクリプトではコンフリクトで除外されていたが、現在は `release/FavstarAndTimemachine` で取り込み済み
- MkPagesエディタ拡張 / ドラッグ&ドロップのスマホ対応・アニメーション
- MkNoteDetailed で返信読み込み、ハッシュタグミュート、正常系ログのデバッグレベル化
- バグ修正群（FTTL歯抜け / 通知残カウント / 添付SJISエンコ / エラー画面操作不能 / 全アカウントログアウト）
- clip登録レートリミット緩和（20→100）、Claude Code GitHub Workflow

### 統合スクリプト（README内 + 実体 `main-統合.sh`）
- merge 順を実際の `mistems-main` の取り込み順に合わせて更新（`mkPostFormExtend` が先頭→後方へ移動した点も反映）
- 新規ブランチを追加: `fix/notification-unread-count`, `release/mkPages-mkDraggable`, `fix/fanout-timeline-redis-gap`, `release/FavstarAndTimemachine`, `fix-textfile-encode`, `fix/error-page-unhandled`
- clip緩和・全アカウントログアウト修正・misskey-js再生成は機能ブランチではなく `mistems-main` 上の直接コミットだったため、コメントで注記
- `MISVER 75` → `94`

## 補足
- 本来のPR希望先は `mistems/mistems` ですが、当該リポジトリはセッションのGitHubスコープ外でアクセスできなかったため、`mistems-readme` ブランチが存在する `fruitriin/misskey` 内にPRを作成しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BP6KjJgM8RcsKYswZ1yygZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BP6KjJgM8RcsKYswZ1yygZ)_